### PR TITLE
Prefix jumptable labels with "jtgt"

### DIFF
--- a/src/disasm/labels.rs
+++ b/src/disasm/labels.rs
@@ -162,7 +162,7 @@ impl fmt::Display for Label {
             Routine => write!(f, "func"),
             Data => write!(f, "D"),
             JmpTbl => write!(f, "jtbl"),
-            JmpTarget => write!(f, "L_JMP"),
+            JmpTarget => write!(f, "jtgt"),
             Local => return write!(f, ".L{:08X}", self.addr),
             Named(ref name) => return f.write_str(&name),
         }?;


### PR DESCRIPTION
 In light of https://github.com/tehzz/n64disasm/issues/5 output labels in jumptables with a unique prefix: `jtgt` for jump target. If nothing else, this will make it easier to adapt `mips_to_c`.